### PR TITLE
Improve yarn detection

### DIFF
--- a/install-spawn.js
+++ b/install-spawn.js
@@ -19,7 +19,7 @@ module.exports = function npmInstallNpm(fullIcu, advice) {
 	var args;
 
 
-	if ( /yarn(\.js)?$/.test(npmPath) ) {
+	if ( /yarn((.*cli)?\.js)?$/.test(npmPath) ) {
 		console.log('Looks like you are using yarn…');
 		installVerb = 'add';
 		args = [ npmPath, 'add', icupkg, '--no-lockfile', '--ignore-scripts' ];


### PR DESCRIPTION
Installing full-icu-npm in a yarn workspace fails.
The reason is because npmPath evaluates to cli.js and not yarn.js.

The test pattern is improved to match npmPath ending with yarn/*/cli.js
together with yarn.js