### PR TITLE
Fix errors when installing `full-icu` with a project local .npmrc file

### DIFF
--- a/install-spawn.js
+++ b/install-spawn.js
@@ -34,7 +34,7 @@ module.exports = function npmInstallNpm(fullIcu, advice) {
 	}
 
 	console.log('full-icu$', cmdPath, args.join(' '));
-	var spawned = child_process.spawnSync(cmdPath, args, { stdio: 'inherit' });
+	var spawned = child_process.spawnSync(cmdPath, args, { stdio: 'inherit', cwd: process.env.INIT_CWD });
 	if(spawned.error) {
 		throw(spawned.error);
 	} else if(spawned.status !== 0) {

--- a/install-spawn.js
+++ b/install-spawn.js
@@ -7,6 +7,8 @@ var fs = require('fs');
 var child_process = require('child_process');
 
 var isglobal = process.env.npm_config_global === 'true';
+var npmrc = '.npmrc';
+var npmrcPath = path.resolve(process.env.INIT_CWD, npmrc);
 
 module.exports = function npmInstallNpm(fullIcu, advice) {
 	var icupkg = fullIcu.icupkg;
@@ -33,8 +35,24 @@ module.exports = function npmInstallNpm(fullIcu, advice) {
 		args = [ 'install', icupkg ];
 	}
 
+	if(fs.existsSync(npmrcPath)) {
+		try {
+			fs.linkSync(npmrcPath, npmrc);
+		} catch(e) {
+			fs.symlinkSync(npmrcPath, npmrc);
+		}
+	}
+
 	console.log('full-icu$', cmdPath, args.join(' '));
-	var spawned = child_process.spawnSync(cmdPath, args, { stdio: 'inherit', cwd: process.env.INIT_CWD });
+	var spawned = child_process.spawnSync(cmdPath, args, { stdio: 'inherit' });
+
+	if(fs.existsSync(npmrc)) {
+		try {
+			fs.unlinkSync(npmrc);
+		} catch(e) {
+		}
+	}
+
 	if(spawned.error) {
 		throw(spawned.error);
 	} else if(spawned.status !== 0) {


### PR DESCRIPTION
`.npmrc` files are used to configure `npm` and can be set on a per-project basis:
<https://docs.npmjs.com/files/npmrc#per-project-config-file>

On install, `npm` sets the `INIT_CWD` process variable to the original directory that ran `npm install`:
<https://docs.npmjs.com/cli/run-script>

~Using `INIT_CWD` we can run the post install step in the correct directory.~
Installing the `icu4c-data` in `INIT_CWD` doesn't work since the path isn't relative to `full-icu` during install. Instead we link to the `.npmrc` locally during install and everything works out.

This is very useful for when folks use private registries.