### PR TITLE
Allow the yarn file to have the cjs filename extension

### DIFF
--- a/install-spawn.js
+++ b/install-spawn.js
@@ -11,7 +11,7 @@ var npmrc = '.npmrc';
 var npmrcPath = path.resolve(process.env.INIT_CWD, npmrc);
 
 // uses semver regex from https://semver.org/
-const YARN_REGEX = /yarn(-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?((.*cli)?\.js)?$/;
+const YARN_REGEX = /yarn(-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?((.*cli)?\.c?js)?$/;
 
 module.exports = function npmInstallNpm(fullIcu, advice) {
 	var icupkg = fullIcu.icupkg;


### PR DESCRIPTION
`yarn` recently starten saving files using the ".cjs" filename extension. This changes the regex to match an optional "c" before the "js" part. It will still match files that are named ".js".